### PR TITLE
feat: add firmware devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,15 @@
+ARG VARIANT=trixie
+FROM mcr.microsoft.com/vscode/devcontainers/base:${VARIANT}
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN sudo apt-get update \
+ && sudo apt-get -y install --no-install-recommends \
+      clang \
+      python3-venv
+
+# Install PlatformIO CLI
+USER vscode
+RUN curl -fsSL -o /tmp/get-platformio.py https://raw.githubusercontent.com/platformio/platformio-core-installer/master/get-platformio.py
+RUN python3 /tmp/get-platformio.py
+RUN echo 'export PATH="$PATH:$HOME/.platformio/penv/bin"' | tee -a /home/vscode/.bashrc /home/vscode/.zshrc 
+RUN echo 'export PATH="$PATH:$HOME/.platformio/penv/bin"' | sudo tee -a /root/.bashrc /root/.zshrc

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+    "build": {
+        "context": ".",
+        "dockerfile": "Dockerfile"
+    },
+    "features": {},
+    "name": "Firmware",
+    "workspaceFolder": "/workspaces/OpenFan-Micro/Firmware"
+}


### PR DESCRIPTION
This PR adds a VSCode Devcontainer which can be used to develop and build firmware code within VSCode.

Theoretically it could also be extended to be used by GitHub CI to automatically build the firmware and deploy it to the GitHub Releases. If you're interested, just let me know!

Currently it is not able to upload firmware to an OpenFan Micro device directly, because of Docker containerization.
I can investigate that further, as soon as my order arrives. Just let me know as well!

If you don't like this at all, feel free to close this PR immediately , no hard feelings! 😉 