### PR TITLE
Openfan unraid

### DIFF
--- a/Firmware/data_pre/index.html
+++ b/Firmware/data_pre/index.html
@@ -225,12 +225,8 @@
               </div>
               <div class="col-12 col-lg-auto mt-3 mt-lg-0">
                 <ul class="list-inline list-inline-dots mb-0">
-                  <li class="list-inline-item">
-                    Copyright &copy; 2024
-                    <a href="https://sasakaranovic.com" target="_blank" class="link-secondary">Karanovic Research</a>.
-                    All rights reserved.
-                  </li>
-                  <li class="list-inline-item">v$FW_VERSION$</li>
+                  <li class="list-inline-item">Made wih <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-inline me-1" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M19.5 12.572l-7.5 7.428l-7.5 -7.428a5 5 0 1 1 7.5 -6.566a5 5 0 1 1 7.5 6.572" /></svg> by <a href="https://sasakaranovic.com" target="_blank" class="link-secondary">Saša Karanović @ Karanovic Research</a></li>
+                  <li class="list-inline-item">OpenFAN Micro running v$FW_VERSION$</li>
                 </ul>
               </div>
             </div>

--- a/Firmware/src/config_openfan.h
+++ b/Firmware/src/config_openfan.h
@@ -27,6 +27,8 @@
 #define MAX_LEN_MAC_BYTES       6
 #define MAX_LEN_MAC_STRING      16
 #define MAX_LEN_DEVICE_NAME     128
+#define OPENFAN_USE_USB_COMM    1
+#define ENABLE_WIFI             1
 
 // Persistent data storage
 typedef struct eeprom_data

--- a/Firmware/src/main.ino
+++ b/Firmware/src/main.ino
@@ -157,8 +157,10 @@ void loop()
     // Update RPM
     fan_tick();
 
+#if ENABLE_WIFI
     // Check WiFi status
     wifi_check();
+#endif
 
 #if OPENFAN_USE_USB_COMM
     // Handle serial comm over USB

--- a/Firmware/src/main.ino
+++ b/Firmware/src/main.ino
@@ -28,6 +28,18 @@ bool bRPM_counting = false;
 bool bStartUpBoost = true;
 uint32_t nStartUpBoost_Timeout = 0;
 
+#if OPENFAN_USE_USB_COMM
+#include "serial_comm.h"
+uint8_t pTxBuffer[COMM_TX_BUFFER_LEN] = {0};
+uint32_t nTxBufferLen = 1;
+uint8_t pRxBuffer[COMM_RX_ASCII_BUFFER_LEN] = {0};
+uint32_t nRxBufferLen = 0;
+uint8_t pPackage[COMM_RX_HEX_BUFFER_LEN] = {0};
+uint32_t nPackageLen = 0;
+volatile bool bRxStarted = false;
+volatile bool bRxComplete = false;
+#endif
+
 void setup()
 {
     Serial.begin(115200);
@@ -38,7 +50,7 @@ void setup()
 
     eeprom_init();
     eeprom_load();
-
+#if ENABLE_WIFI
     set_device_mdns_name();
     WiFi.setHostname(mdnsName.c_str());
 
@@ -50,7 +62,7 @@ void setup()
     Serial.println(txPower);
 
     delay(1000);
-
+#endif
     // Setup GPIO
     pinMode(PIN_LED_ACT, OUTPUT);
     digitalWrite(PIN_LED_ACT, HIGH);
@@ -74,6 +86,7 @@ void setup()
     fan_setup();
     set_pwm(eepromData.last_percent);
 
+#if ENABLE_WIFI
     bool res;
     res = wifiManager.autoConnect("SK-OpenFAN");
 
@@ -111,7 +124,7 @@ void setup()
 
     Serial.print("WiFi IP: ");
     Serial.println(WiFi.localIP());
-
+#endif
     // Debug message to signal we are initialized and entering loop
     Serial.println("Ready to go.");
     digitalWrite(PIN_LED_ACT, LOW);
@@ -123,6 +136,10 @@ void setup()
     Serial.print(FAN_STARTUP_BOOST_TIME);
     Serial.println(" miliseconds");
     set_pwm(FAN_STARTUP_BOOST_PWM);
+
+#if OPENFAN_USE_USB_COMM
+    host_comm_rearm();
+#endif
 }
 
 
@@ -142,6 +159,11 @@ void loop()
 
     // Check WiFi status
     wifi_check();
+
+#if OPENFAN_USE_USB_COMM
+    // Handle serial comm over USB
+    serial_comm_tick();
+#endif
 }
 
 

--- a/Firmware/src/serial_comm.h
+++ b/Firmware/src/serial_comm.h
@@ -1,0 +1,29 @@
+#ifndef __HOST_COMMUNICATION_INC_H__
+#define __HOST_COMMUNICATION_INC_H__
+
+#define COMM_START_CHARACTER        '>'
+#define COMM_END_CHARACTER          '\n'
+#define COMM_ALT_END_CHARACTER      '\r'
+#define COMM_MIN_MESSAGE_LEN        3
+#define COMM_RESPONSE_CHARACTER     '<'
+#define COMM_RX_ASCII_BUFFER_LEN    128
+#define COMM_RX_HEX_BUFFER_LEN      COMM_RX_ASCII_BUFFER_LEN/2 - 1
+#define COMM_TX_BUFFER_LEN          128
+
+#define COMM_PROTOCOL_VERSION       2
+
+typedef enum comm_cmd
+{
+    CMD_FIRST,
+    CMD_FAN_ALL_GET_RPM     = 0x00,
+    CMD_FAN_GET_RPM         = 0x01,
+    CMD_FAN_SET_PWM         = 0x02,
+    CMD_FAN_SET_ALL_PWM     = 0x03,
+    CMD_FAN_SET_RPM         = 0x04,
+    CMD_HW_INFO             = 0x05,
+    CMD_FW_INFO             = 0x06,
+
+    CMD_LAST                = CMD_FW_INFO,
+} comm_cmd_t;
+
+#endif /* __HOST_COMMUNICATION_INC_H__ */

--- a/Firmware/src/serial_comm.ino
+++ b/Firmware/src/serial_comm.ino
@@ -1,0 +1,329 @@
+#if OPENFAN_USE_USB_COMM
+
+void serial_comm_tick(void)
+{
+    serial_comm_receive();
+    host_comm_tick();
+}
+
+static void serial_comm_receive(void)
+{
+    int available = 0;
+    uint8_t ch;
+    available = Serial.available();
+
+    if (available>0)
+    {
+        for (uint8_t i=0; i<available; i++)
+        {
+            ch = (uint8_t)Serial.read();
+            host_comm_receive_data(&ch, 1);
+        }
+    }
+}
+
+void host_comm_process_request(comm_cmd_t cmd, uint8_t *pData, uint32_t nDataLen)
+{
+    uint16_t rpm = 0;
+    pTxBuffer[0] = COMM_RESPONSE_CHARACTER;
+    nTxBufferLen = 1;
+    response_add_byte(cmd);
+    response_add_chr('|');
+
+    switch (cmd)
+    {
+        case CMD_FAN_ALL_GET_RPM:
+            // Add RPM for first fan
+            response_add_byte(0);
+            response_add_chr(':');
+            response_add_u16((uint16_t)fan_rpm);
+            response_add_chr(';');
+            // Fake remaining data
+            for(uint8_t i=1; i<10; i++)
+            {
+                rpm=0;
+                response_add_byte(i);
+                response_add_chr(':');
+                response_add_u16(0);
+                if(i<10)
+                {
+                    response_add_chr(';');
+                }
+            }
+            break;
+
+        case CMD_FAN_GET_RPM:
+            rpm=0;
+            if (pData[0])
+            {
+                rpm = (uint16_t)fan_rpm;
+            }
+            response_add_byte(pData[0]);
+            response_add_chr(':');
+            response_add_u16(rpm);
+            break;
+
+        case CMD_FAN_SET_PWM:
+            if (pData[0] == 0)
+            {
+                set_pwm(pData[1]);
+            }
+            response_add_byte(pData[0]);
+            response_add_chr(':');
+            response_add_byte(pData[1]);
+            break;
+
+        case CMD_FAN_SET_ALL_PWM:
+            set_pwm(pData[1]);
+            response_add_byte(pData[0]);
+            break;
+
+        case CMD_FAN_SET_RPM:
+            // FIXME: This is unsupported at the moment
+            response_add_byte(pData[0]);
+            response_add_chr(':');
+            response_add_byte(pData[1]);
+            response_add_byte(pData[2]);
+            break;
+
+        case CMD_HW_INFO:
+            response_add_str("\r\n");
+            response_add_str("HW_REV:01\r\n");
+            response_add_str("MCU:OpenFAN_Micro_ESP32\r\n");
+            response_add_str("USB:NATIVE\r\n");
+            response_add_str("FAN_CHANNELS_TOTAL:1\r\n");
+            response_add_str("FAN_CHANNELS_ARCH:1\r\n");
+            response_add_str("FAN_CHANNELS_DRIVER:GPIO_PWM\r\n");
+            break;
+
+        case CMD_FW_INFO:
+            response_add_str("FW_REV:OpenFAN_Micro_02\r\n");
+            response_add_str("PROTOCOL_VERSION:02\r\n");
+            break;
+
+        default:
+            Serial.println("Unsupported or invalid command");
+    }
+
+    host_comm_send_response();
+}
+
+
+static void host_comm_send_response(void)
+{
+    pTxBuffer[nTxBufferLen++] = '\r';
+    pTxBuffer[nTxBufferLen++] = '\n';
+    Serial.write(pTxBuffer, nTxBufferLen);
+
+    memset(pTxBuffer, '\0', COMM_TX_BUFFER_LEN);
+    nTxBufferLen = 0;
+}
+
+void host_comm_receive_data(uint8_t *pData, uint32_t nDataLen)
+{
+    if (pData == NULL)
+    {
+        Serial.println("Invalid pointer!");
+        return;
+    }
+
+    // We already received a package and parse is pending
+    if (bRxComplete)
+    {
+        return;
+    }
+
+    // Receive data
+    for (uint32_t i=0; i<nDataLen; i++)
+    {
+        if (( (pData[i] == COMM_END_CHARACTER) || (pData[i] == COMM_ALT_END_CHARACTER)) && (!bRxComplete))
+        {
+            bRxComplete = true;
+            return;
+        }
+        else
+        {
+            pRxBuffer[nRxBufferLen++] = pData[i];
+        }
+
+    }
+}
+
+void host_comm_parse_package(uint8_t *pPackageStart, uint32_t nLen)
+{
+    // Convert entire array from ASCII to raw values
+    if (ascii_array_to_hex_array(pPackageStart, nLen, pPackage, &nPackageLen))
+    {
+        host_comm_process_request((comm_cmd_t)pPackage[0], &pPackage[1], nPackageLen-1);
+    }
+}
+
+
+
+void host_comm_tick(void)
+{
+    bool bValidMsg = false;
+
+    if (bRxComplete)
+    {
+        if(nRxBufferLen < COMM_MIN_MESSAGE_LEN)
+        {
+            Serial.print("Invalid message lenght d=");
+            Serial.println(nRxBufferLen, DEC);
+            host_comm_rearm();
+            return;
+        }
+
+        // Search for start character
+        for(uint32_t i=0; i<nRxBufferLen; i++)
+        {
+            if(pRxBuffer[i] == COMM_START_CHARACTER)
+            {
+                host_comm_parse_package(&pRxBuffer[i+1], nRxBufferLen-i-1);
+                bValidMsg = true;
+                break;
+            }
+        }
+
+        if(!bValidMsg)
+        {
+            Serial.println("No start character found. Ignoring package.");
+        }
+
+        host_comm_rearm();
+        return;
+    }
+}
+
+
+static void host_comm_rearm(void)
+{
+    memset(pRxBuffer, '\0', COMM_RX_ASCII_BUFFER_LEN);
+    memset(pPackage, '\0', COMM_RX_HEX_BUFFER_LEN);
+    nRxBufferLen = 0;
+    nPackageLen = 0;
+    bRxComplete = false;
+}
+
+static uint8_t buffer_to_uint8(uint8_t *pBuffer)
+{
+    if(pBuffer==NULL)
+    {
+        Serial.println("Invalid pointer!");
+        return 0;
+    }
+
+    uint8_t upper = ascii_to_hex(pBuffer[0]);
+    uint8_t lower = ascii_to_hex(pBuffer[1]);
+
+    return (upper<<4) | lower;
+}
+
+// Convert ASCII HEX character 0-9 or A-F to HEX value
+static uint8_t ascii_to_hex(uint8_t ascii)
+{
+
+    if( (ascii>='0') && (ascii<='9') )
+    {
+        return ascii - '0';
+    }
+    else if ( (ascii >= 'A') && (ascii <= 'F') )
+    {
+        return ascii - 'A' + 10;
+    }
+    else if ( (ascii >= 'a') && (ascii <= 'f') )
+    {
+        return ascii - 'a' + 10;
+    }
+    else
+    {
+        Serial.println("Invalid character!");
+        return 0;
+    }
+}
+
+// Convert ASCII HEX array to HEX array
+// This function will rewrite an ASCII HEX array (2 characters per byte) to hex array (1 byte per byte)
+// The resulting array will be half the size and contain RAW HEX values
+static bool ascii_array_to_hex_array(uint8_t *pASCII, uint32_t nLen, uint8_t *pTarget, uint32_t *nHexLen)
+{
+    if(pASCII==NULL)
+    {
+        Serial.println("Invalid pointer!");
+        return false;
+    }
+
+    if(nLen<=0)
+    {
+        Serial.println("Invalid buffer length");
+        return false;
+    }
+
+    uint8_t raw = 0;
+    uint32_t raw_pos = 0;
+
+    // Lenght is converted from USART ASCII package
+    // so we need to multiply it by 2 to account for
+    // ASCII values (2 byte)
+    for (uint32_t i=0; i<nLen; i+=2)
+    {
+        // Convert ASCII bytes ie. FA to raw hex
+        raw = (ascii_to_hex(pASCII[i]) << 4);
+        raw |= ascii_to_hex(pASCII[i+1]);
+
+        // Finally update raw byte
+        pTarget[raw_pos++] = raw;
+    }
+
+    *nHexLen = raw_pos;
+    return true;
+}
+
+
+static void response_add_data(uint8_t *pData, uint32_t nLen)
+{
+    if(pData==NULL)
+    {
+        Serial.println("Invalid pointer!");
+        return;
+    }
+
+    for(uint32_t i=0; i<nLen; i++)
+    {
+        response_add_byte(pData[i]);
+    }
+}
+
+static void response_add_byte(uint8_t data)
+{
+    sprintf((char *)&pTxBuffer[nTxBufferLen], "%02X", data);
+    nTxBufferLen += 2;
+}
+
+static void response_add_u32(uint32_t data)
+{
+    sprintf((char *)&pTxBuffer[nTxBufferLen], "%08lX", data);
+    nTxBufferLen += 8;
+}
+
+static void response_add_u16(uint16_t data)
+{
+    sprintf((char *)&pTxBuffer[nTxBufferLen], "%04X", data);
+    nTxBufferLen += 4;
+}
+
+static void response_add_str(const char *pStr)
+{
+    uint32_t nLen = strlen(pStr);
+    strncpy((char *)&pTxBuffer[nTxBufferLen], pStr, nLen);
+    nTxBufferLen += nLen;
+}
+
+static void response_add_chr(char data)
+{
+    pTxBuffer[nTxBufferLen++] = data;
+}
+
+
+
+#endif

--- a/Firmware/src/serial_comm.ino
+++ b/Firmware/src/serial_comm.ino
@@ -88,8 +88,8 @@ void host_comm_process_request(comm_cmd_t cmd, uint8_t *pData, uint32_t nDataLen
 
         case CMD_HW_INFO:
             response_add_str("\r\n");
-            response_add_str("HW_REV:01\r\n");
-            response_add_str("MCU:OpenFAN_Micro_ESP32\r\n");
+            response_add_str("HW_REV:04\r\n");
+            response_add_str("MCU:OpenFAN_Micro_ESP32C3\r\n");
             response_add_str("USB:NATIVE\r\n");
             response_add_str("FAN_CHANNELS_TOTAL:1\r\n");
             response_add_str("FAN_CHANNELS_ARCH:1\r\n");
@@ -97,7 +97,7 @@ void host_comm_process_request(comm_cmd_t cmd, uint8_t *pData, uint32_t nDataLen
             break;
 
         case CMD_FW_INFO:
-            response_add_str("FW_REV:OpenFAN_Micro_02\r\n");
+            response_add_str("FW_REV:02\r\n");
             response_add_str("PROTOCOL_VERSION:02\r\n");
             break;
 

--- a/Firmware/src/serial_comm.ino
+++ b/Firmware/src/serial_comm.ino
@@ -25,6 +25,7 @@ static void serial_comm_receive(void)
 void host_comm_process_request(comm_cmd_t cmd, uint8_t *pData, uint32_t nDataLen)
 {
     uint16_t rpm = 0;
+    uint8_t percent = 0;
     pTxBuffer[0] = COMM_RESPONSE_CHARACTER;
     nTxBufferLen = 1;
     response_add_byte(cmd);
@@ -66,7 +67,8 @@ void host_comm_process_request(comm_cmd_t cmd, uint8_t *pData, uint32_t nDataLen
         case CMD_FAN_SET_PWM:
             if (pData[0] == 0)
             {
-                set_pwm(pData[1]);
+                percent = (pData[1] * 100.0 / 255.0);
+                set_pwm(percent);
             }
             response_add_byte(pData[0]);
             response_add_chr(':');
@@ -74,16 +76,9 @@ void host_comm_process_request(comm_cmd_t cmd, uint8_t *pData, uint32_t nDataLen
             break;
 
         case CMD_FAN_SET_ALL_PWM:
-            set_pwm(pData[1]);
+            percent = (pData[1] * 100.0 / 255.0);
+            set_pwm(percent);
             response_add_byte(pData[0]);
-            break;
-
-        case CMD_FAN_SET_RPM:
-            // FIXME: This is unsupported at the moment
-            response_add_byte(pData[0]);
-            response_add_chr(':');
-            response_add_byte(pData[1]);
-            response_add_byte(pData[2]);
             break;
 
         case CMD_HW_INFO:


### PR DESCRIPTION
- Adding serial API to make the controller work with Unraid app (and any OpenFAN Controller 
- Updating serial comm response strings.
- Adding ifdef for wifi check. Removing unsupported command (RPM). Calculating PWM percent value before passing to set_fan.