### PR TITLE
Fix leading zeros in generated version numbers

### DIFF
--- a/Firmware/make_version.py
+++ b/Firmware/make_version.py
@@ -7,9 +7,9 @@ def write_version_to_file(filepath, contents):
 
 def make_version_string():
     now = datetime.datetime.now()
-    year = now.strftime('%Y')
-    month = now.strftime('%m')
-    day = now.strftime('%d')
+    year = now.year
+    month = now.month
+    day = now.day
 
     version_header = \
 f"""#ifndef __OPENFAN_MICRO_FW_VERSION_H_INC__


### PR DESCRIPTION
## Summary

Use integer datetime attributes when generating firmware version macros, preventing zero-padded values from being written as C/C++ integer literals.

## Problem

`strftime` returns zero-padded month and day strings. This can generate values such as `#define VERSION_MINOR 08`, which is parsed as an invalid octal literal and causes the PlatformIO build to fail.

## Validation

- Reproduced `invalid digit "8" in octal constant` on 2026-08-16
- `pio run` succeeds after the change
- Successfully flashed and tested the firmware on OpenFAN Micro hardware